### PR TITLE
[fix] Wait for update completion

### DIFF
--- a/youtube.sh
+++ b/youtube.sh
@@ -2,5 +2,5 @@
 umask 000
 youtube-dl -x $1 --audio-format mp3 --restrict-filenames -w -c -o "/home/youtube/mp3/%(title)s.%(ext)s"
 NEW=$(youtube-dl --get-filename $1 --restrict-filenames -w -c -o "%(title)s.mp3")
-mpc update youtube
+mpc update --wait youtube
 mpc add youtube/mp3/"$NEW"


### PR DESCRIPTION
`mpc update` se lance en arrière plan par défaut.

De ce fait, l'opération n'est pas forcément terminée quand la commande `mpc add` se lance. Ainsi, le fichier n'est pas trouvé, et le message d'erreur suivant est affiché:

```
[download] 100% of 36.66MiB in 00:05
[youtube] Post-process file tralala.mp3 exists, skipping
Updating DB (#4) ...
volume:100%   repeat: off   random: off   single: off   consume: off
error: directory or file not found
```

Ce patch semble régler le problème.
